### PR TITLE
Remove Quantcast tracking code from Mapping file

### DIFF
--- a/xml/cc_mapping.xml
+++ b/xml/cc_mapping.xml
@@ -47,8 +47,6 @@
 </cookies><cookies><cookie-name _cc_mapping_cookie="4349">bp_completed_create_steps</cookie-name>
 </cookies><cookies><cookie-name _cc_mapping_cookie="4350">bp_messages_</cookie-name>
 </cookies><cookies><cookie-name _cc_mapping_cookie="4348">bp_new_group_id</cookie-name>
-</cookies></cc_mapping><cc_mapping><plugin-name>jetpack</plugin-name>
-<cookies><cookie-name _cc_mapping_cookie="4179">__qca</cookie-name>
 </cookies></cc_mapping><cc_mapping><plugin-name>si-contact-form</plugin-name>
 <cookies><cookie-name _cc_mapping_cookie="4125">PHPSESSID</cookie-name>
 </cookies><cookies><cookie-name _cc_mapping_cookie="4237">vc_widget_generic-expert</cookie-name>


### PR DESCRIPTION
Quantcast was removed from Jetpack in version 2.8, on January 31, 2014:

https://github.com/Automattic/jetpack/commit/e8150313c897464965c3a2886a78eaf77ea87aba#diff-eb6b6c90251ab33cee784713c451e6d8R103
https://github.com/Automattic/jetpack/commit/d15b2466dc3fced8b493edae88ba3185ce31ce0a

There is no need to include the Quantcast cookie in the report anymore.

Reported here:
https://wordpress.org/support/topic/jetpack-imposed-quantcast-cookie-_qca-what-is-it-for
